### PR TITLE
Add Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:stretch-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN useradd -d /lynis-report-converter -U lynis
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+       htmldoc libxml-writer-perl libarchive-zip-perl libjson-perl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY . /lynis-report-converter
+
+USER lynis
+
+WORKDIR /lynis-report-converter
+
+ENTRYPOINT ["/lynis-report-converter/lynis-report-converter.pl"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Where:
 -o|--output                     Specifies the output file to print the report to.
 ```
 
+### Docker
+
+```
+docker build -t <imagename> .
+docker run --rm -v /local-report-dir:/reports lynis-report-converter -o /reports/report.html -i /reports/lynis-report.dat
+```
+
 ### Output Features:
 * HTML (default)
 	* Summarizes the lynis report into a single HTML file.


### PR DESCRIPTION
There's a docker image for lynis-report-converter on [docker hub](https://hub.docker.com/r/kuznetsovv/lynis-report-converter/)  but it's not flexible at all. 

I think that adding an official Dockerfile will be helpful. I've included a basic dockerfile (with debian stretch slim as a base) and some instruction on how to build and run the image.